### PR TITLE
ci: update Docker actions to Node 24 before June 2 deadline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Look for `package.json` and `lock` files in the `root` directory
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,13 +56,13 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary

- Bumps `docker/setup-buildx-action` v3 → v4.0.0
- Bumps `docker/login-action` v3 → v4.1.0
- Bumps `docker/build-push-action` v6 → v7.1.0
- Adds `github-actions` ecosystem to Dependabot so future action pin updates are automated

All three previous versions ran on Node 20. GitHub forces Node 24 as the default runtime on **June 2, 2026** — after that date, Node 20 actions become hard failures.

Breaking changes in the major bumps were audited: removed inputs/env vars (`DOCKER_BUILD_NO_SUMMARY`, `DOCKER_BUILD_EXPORT_RETENTION_DAYS`, deprecated `setup-buildx-action` inputs) are not used in these workflows.

## Test plan

- [ ] CI `test` job passes (typecheck + mocha — unchanged)
- [ ] CI `build` job passes with `setup-buildx-action@v4` + `build-push-action@v7` (`push: false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)