### PR TITLE
ci: auto-release and image prune on successful deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,6 +95,7 @@ jobs:
             docker compose up -d
             sleep 5
             docker compose ps --status running --quiet | grep -q . || { docker compose logs; exit 1; }
+            docker image prune -a -f
 
   register:
     needs: [deploy, changes]
@@ -109,3 +110,17 @@ jobs:
           script: |
             cd ~/ubot
             docker compose run --rm ubot node dist/deploy-commands.js
+
+  release:
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          TAG="v$(date -u +%Y.%m.%d)-${RUN_NUMBER}"
+          gh release create "$TAG" --title "$TAG" --generate-notes --repo cjlaw/ubot --target ${{ github.sha }}


### PR DESCRIPTION
## Summary
- Adds `release` job to `deploy.yml` that fires after every successful deploy
- Tags the deployed commit as `v{YYYY.MM.DD}-{run-number}` with auto-generated release notes anchored from `v0.0.1`
- Prunes stale Docker images on the VM after the health check passes

## Test plan
- [ ] Merge this PR (CI runs; no deploy triggered — only `.github/` changed)
- [ ] Push any deployable change to `main` and confirm a new release appears in the GitHub Releases tab with the expected tag format

🤖 Generated with [Claude Code](https://claude.com/claude-code)